### PR TITLE
feat: allow configurable chat flow order

### DIFF
--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -133,6 +133,7 @@ export const agentsService = {
     if (data.dynamicInfoSchemaNaturalText !== undefined) serverData.dynamic_info_schema_natural_text = data.dynamicInfoSchemaNaturalText;
     if (data.postCollectionInformationText !== undefined) serverData.post_collection_information_text = data.postCollectionInformationText;
     if (data.modules !== undefined) serverData.modules_jsonb = data.modules;
+    if (data.chatFlow !== undefined) serverData.chat_flow_jsonb = data.chatFlow;
     
     return await apiClient.patch(ENDPOINTS.AGENTS.UPDATE(orgId, agentId), serverData);
   },

--- a/server/src/controllers/conversations_controller.js
+++ b/server/src/controllers/conversations_controller.js
@@ -69,7 +69,7 @@ export class ConversationsController {
       const assistantMsg = await ConversationService.sendAssistant({ conversationId: id, text: response.uiText || '', citations: response.citations || [] });
       const durationSec = (Date.now() - routeStart) / 1000;
         try { console.log('Conversation response complete', { conversationId: id, agentId, userId: req.user.id, duration_s: Number(durationSec.toFixed(3)) }); } catch {}
-      const payload = { user: userMsg, assistant: assistantMsg, citations: response.citations || [], conversationId: id };
+      const payload = { user: userMsg, assistant: assistantMsg, citations: response.citations || [], conversationId: id, doneSections: response.doneSections || [] };
       if (createdFresh && welcomeMsg) payload.welcome = welcomeMsg;
       return res.status(201).json(payload);
     } catch (err) { next(err); }

--- a/server/src/db/migrations/20250903170520-0018-add-chat-flow-jsonb.js
+++ b/server/src/db/migrations/20250903170520-0018-add-chat-flow-jsonb.js
@@ -1,0 +1,15 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(queryInterface) {
+  await queryInterface.addColumn('agents', 'chat_flow_jsonb', {
+    type: DataTypes.JSONB,
+    allowNull: false,
+    defaultValue: ['DYNAMIC_INFO_SCHEMA_STATE', 'POST_COLLECTION_INFORMATION', 'LEAD_SCHEMA_STATE']
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.removeColumn('agents', 'chat_flow_jsonb');
+}
+
+export default { up, down };

--- a/server/src/db/sequelize.js
+++ b/server/src/db/sequelize.js
@@ -52,6 +52,7 @@ export const ensureOptionalColumns = async () => {
     // Add new columns if they are missing; safe to run multiple times
     await sequelize.query("ALTER TABLE agents ADD COLUMN IF NOT EXISTS dynamic_info_schema_natural_text TEXT;");
     await sequelize.query("ALTER TABLE agents ADD COLUMN IF NOT EXISTS post_collection_information_text TEXT;");
+    await sequelize.query("ALTER TABLE agents ADD COLUMN IF NOT EXISTS chat_flow_jsonb JSONB DEFAULT '[\"DYNAMIC_INFO_SCHEMA_STATE\",\"POST_COLLECTION_INFORMATION\",\"LEAD_SCHEMA_STATE\"]'::jsonb;");
   } catch (error) {
     console.warn('Optional schema ensure failed', { error: error?.message });
   }

--- a/server/src/models/agent.js
+++ b/server/src/models/agent.js
@@ -57,11 +57,15 @@ Agent.init(
       type: DataTypes.JSONB,
       allowNull: false,
       defaultValue: {}
-    }
-    ,
+    },
     post_collection_information_text: {
       type: DataTypes.TEXT,
       allowNull: true
+    },
+    chat_flow_jsonb: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: ['DYNAMIC_INFO_SCHEMA_STATE', 'POST_COLLECTION_INFORMATION', 'LEAD_SCHEMA_STATE']
     }
   },
   {
@@ -74,5 +78,3 @@ Agent.init(
 );
 
 export default Agent;
-
-

--- a/server/src/services/bot/prompt_builder.js
+++ b/server/src/services/bot/prompt_builder.js
@@ -60,7 +60,8 @@ export async function buildSinglePrompt({
   leadSchema,
   dynSchema,
   passages = [],
-  includeBackHint = true
+  includeBackHint = true,
+  completedSections = []
 }) {
   const agentName = agent?.dataValues?.name || '';
   const businessName = agentName;
@@ -71,6 +72,14 @@ export async function buildSinglePrompt({
   const lang = detectLanguageFromText(
     userMessage || history?.[history.length - 1]?.content_jsonb?.text || ''
   );
+
+  const chatFlow = Array.isArray(agent?.dataValues?.chat_flow_jsonb)
+    ? agent.dataValues.chat_flow_jsonb
+    : ['DYNAMIC_INFO_SCHEMA_STATE', 'POST_COLLECTION_INFORMATION', 'LEAD_SCHEMA_STATE'];
+  const chatFlowOrder = `[${chatFlow.join(', ')}]`;
+  const completedList = Array.isArray(completedSections) && completedSections.length > 0
+    ? `[${completedSections.join(', ')}]`
+    : '[]';
 
   const variables = {
     agentName: agentName,
@@ -85,7 +94,9 @@ export async function buildSinglePrompt({
     chatHistory: formatHistory(history) || '',
     backHint: includeBackHint ? 'Users may type "back" to revisit the previous question or "skip" to skip the current one.' : '',
     currentUserMessage: userMessage || '',
-    allowQuestionsBeforeGathering: allowQuestionsBeforeGathering ? 'true' : 'false'
+    allowQuestionsBeforeGathering: allowQuestionsBeforeGathering ? 'true' : 'false',
+    chatFlowOrder,
+    completedSections: completedList
   };
 
   const promptText = await loadPrompt('single_prompt.txt', variables, lang.locale);

--- a/server/src/services/bot/prompts/single_prompt.txt
+++ b/server/src/services/bot/prompts/single_prompt.txt
@@ -4,21 +4,22 @@ Respond in {{languageName}} (direction: {{textDirection}}).
 Keep answers concise and friendly.
 
 <Context>
--User defined various configurations, you need to take into account.
--User provided several parts with information you need to collect from the user, they apear below -
-LEAD_SCHEMA_STATE - basic lead info.
-DYNAMIC_INFO_SCHEMA_STATE - dynamic data, related to user and domain. User may kept them blank, in this case ignroe.
+- User defined various configurations you must consider.
+- The user provided several sections of information to handle:
+  LEAD_SCHEMA_STATE - contact and lead details to gather.
+  DYNAMIC_INFO_SCHEMA_STATE - additional domain-specific questions (optional but still ask all listed).
+  POST_COLLECTION_INFORMATION - final business message to send when its turn comes.
 
-
-The schemas are updated after each response, when you collect a field it will be marked collected = true.
+The schemas are updated after each response; collected fields are marked collected = true.
 
 <Chat Flow>
 Language = user language.
+Completed sections so far: {{completedSections}}
 
-1. First msg - start with the first batch of questions per below, or ask a general question if you have no infomration to gather.
-2. Collect in this order, if exit  [DYNAMIC_INFO_SCHEMA_STATE, POST_COLLECTION_INFORMATION, LEAD_SCHEMA_STATE]
-3. you can ask upto 3 questions at a time.
-4. When done collecting all required info (mark intake_complete = true), send the POST-COLLECTION INFORMATION to the user in their language, tailoring the phrasing to the user's provided attributes (e.g., male/female and any other relevant details). If no post-collection information is provided, give a polite confirmation instead.
+1. Start with the first section in the flow or ask a general question if nothing to gather.
+2. Execute sections in this order if they exist: {{chatFlowOrder}}. After finishing a section, include its name in done_sections.
+3. You can ask up to 3 questions at a time.
+4. When executing POST_COLLECTION_INFORMATION, send the text in the user's language tailored to collected attributes. Mark intake_complete true only after all required lead fields are collected.
 5. If user asks questions at any time, follow Answering Behavior below.
 
 <Answering Behavior>
@@ -79,5 +80,6 @@ Return ONLY valid JSON with this shape, no extra text:
   "lead_updates": [{"questionId": string, "value": string}] | [],
   "dyn_updates": [{"questionId": string, "value": string}] | [],
   "intake_complete": boolean,              // true when all required lead fields are collected (dynamic info optional)
+  "done_sections": [string] | [],          // names of sections just completed
   "citations": [number] | []               // numbers refer to CONTEXT passage numbers
 }


### PR DESCRIPTION
## Summary
- allow agents to configure conversation flow order
- track completed sections and pass dynamic order to bot prompt
- store chat flow in database schema

## Testing
- `npm test --prefix server -- --passWithNoTests`
- `npm run lint --prefix client` *(fails: no-unused-vars, react-hooks/exhaustive-deps)*

------
https://chatgpt.com/codex/tasks/task_e_68b96e2a9cfc8324aa23bb5a22ab9d1c